### PR TITLE
chore: set type to module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Small and powerful client-side router for Web Components. Framework-agnostic.",
   "main": "dist/vaadin-router.js",
   "module": "dist/vaadin-router.js",
+  "type": "module",
   "repository": "vaadin/vaadin-router",
   "keywords": [
     "Vaadin",


### PR DESCRIPTION
The `type` property of `package.json` may be used by frontend tooling (e.g Webpack, Vite) in determining whether the package's entry point is a conventional CJS or ES module. If no property is specified, the entry point may be treated as a CJS module. As an illustration, here is a warning that Vite shows when you import the Vaadin router:

> @vaadin/router doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.

This PR explicitly sets the `type` property to `module` to avoid possible misinterpretation.

Related to vaadin/flow#12574

## Type of change

- [x] Internal
