### PR TITLE
add option to enable native view transitions using the new View Transitions API

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import resolve from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
-import pkg from './package.json';
+import pkg from './package.json' assert {type: "json"};
 
 const plugins = [
   // The 'node-resolve' plugin allows Rollup to resolve bare module imports like


### PR DESCRIPTION

## Description

This is a simple addition to optionally enable the new [View Transition API](https://developer.chrome.com/docs/web-platform/view-transitions/)

Fixes #841 

## Type of change

- [ ] Bugfix
- [X ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
